### PR TITLE
Add build-image.sh script for building SOGo container based on Archlinux with buildah

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir /var/spool/sogo && chown sogo:sogo /var/spool/sogo
 ADD sogod.ini /etc/supervisor.d/sogod.ini
 ADD apache.ini /etc/supervisor.d/apache.ini
 ADD cronie.ini /etc/supervisor.d/cronie.ini
+ADD memcached.ini /etc/supervisor.d/memcached.ini
 
 WORKDIR /
 CMD ["/usr/sbin/supervisord", "--nodaemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM archlinux:latest
-
+ENV LD_PRELOAD=/usr/lib/libytnef.so
 RUN pacman --noconfirm --needed -Syu && pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef cronie && yes | pacman -Sccq
 RUN sed 's/.*MAKEFLAGS=.*/MAKEFLAGS="-j$(nproc)"/' -i /etc/makepkg.conf
 RUN sed 's/^# \(%wheel.*NOPASSWD.*\)/\1/' -i /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,20 @@
 FROM archlinux:latest
 ENV LD_PRELOAD=/usr/lib/libytnef.so
-RUN pacman --noconfirm --needed -Syu && pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef cronie && yes | pacman -Sccq
-RUN sed 's/.*MAKEFLAGS=.*/MAKEFLAGS="-j$(nproc)"/' -i /etc/makepkg.conf
-RUN sed 's/^# \(%wheel.*NOPASSWD.*\)/\1/' -i /etc/sudoers
-RUN useradd -r build -G wheel
-
-RUN mkdir /build
+RUN pacman --noconfirm --needed -Syu && pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef cronie && yes | pacman -Sccq && \
+  sed 's/.*MAKEFLAGS=.*/MAKEFLAGS="-j$(nproc)"/' -i /etc/makepkg.conf && sed 's/^# \(%wheel.*NOPASSWD.*\)/\1/' -i /etc/sudoers && useradd -r build -G wheel &&  mkdir /build
 
 WORKDIR /build
-RUN git clone --depth 1 https://aur.archlinux.org/libwbxml.git
-RUN chown -R build ./libwbxml
+RUN git clone --depth 1 https://aur.archlinux.org/libwbxml.git && chown -R build ./libwbxml 
 WORKDIR /build/libwbxml
 RUN sudo -u build makepkg -is --noconfirm && rm -rf /build/libwbxml && yes | pacman -Sccq
 
 WORKDIR /build
-RUN git clone --depth 1 https://aur.archlinux.org/sope.git
-RUN chown -R build ./sope
+RUN git clone --depth 1 https://aur.archlinux.org/sope.git &&  chown -R build ./sope
 WORKDIR /build/sope
 RUN sudo -u build makepkg -is --noconfirm && rm -rf /build/sope && yes | pacman -Sccq
 
 WORKDIR /build
-RUN git clone --depth 1 https://aur.archlinux.org/sogo.git
-RUN chown -R build ./sogo
+RUN git clone --depth 1 https://aur.archlinux.org/sogo.git &&  chown -R build ./sogo
 WORKDIR /build/sogo
 RUN sudo -u build makepkg -is --noconfirm && rm -rf /build/sogo && yes | pacman -Sccq
 
@@ -38,8 +31,7 @@ COPY cronie.ini /etc/supervisor.d/cronie.ini
 COPY memcached.ini /etc/supervisor.d/memcached.ini
 
 # clean up
-RUN pacman --noconfirm -Rcns base-devel git && yes | pacman -Sccq
-RUN rm -rf /tmp/* /var/tmp/* /var/cache/pacman/pkg/*
+RUN pacman --noconfirm -Rcns base-devel git && yes | pacman -Sccq && rm -rf /tmp/* /var/tmp/* /var/cache/pacman/pkg/*
 
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,15 @@ RUN sudo -u build makepkg -is --noconfirm && rm -rf /build/sogo && yes | pacman 
 
 
 COPY httpd.conf /etc/httpd/conf/httpd.conf
-ADD event_listener.ini /etc/supervisor.d/event_listener.ini
-ADD event_listener.sh /usr/local/bin/event_listener.sh
+COPY event_listener.ini /etc/supervisor.d/event_listener.ini
+COPY event_listener.sh /usr/local/bin/event_listener.sh
 RUN chmod +x /usr/local/bin/event_listener.sh
 RUN mkdir /var/run/sogo && chown sogo:sogo /var/run/sogo
 RUN mkdir /var/spool/sogo && chown sogo:sogo /var/spool/sogo
-ADD sogod.ini /etc/supervisor.d/sogod.ini
-ADD apache.ini /etc/supervisor.d/apache.ini
-ADD cronie.ini /etc/supervisor.d/cronie.ini
-ADD memcached.ini /etc/supervisor.d/memcached.ini
+COPY sogod.ini /etc/supervisor.d/sogod.ini
+COPY apache.ini /etc/supervisor.d/apache.ini
+COPY cronie.ini /etc/supervisor.d/cronie.ini
+COPY memcached.ini /etc/supervisor.d/memcached.ini
 
 WORKDIR /
 CMD ["/usr/sbin/supervisord", "--nodaemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,8 @@ RUN chown -R build ./sogo
 WORKDIR /build/sogo
 RUN sudo -u build makepkg -is --noconfirm && rm -rf /build/sogo && yes | pacman -Sccq
 
-RUN sed 's/^Listen .*/Listen 20001/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's|^ErrorLog.*|ErrorLog /dev/stderr|' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_rewrite\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_proxy\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_proxy_http\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_proxy_http2\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_proxy_balancer\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN sed 's/^#\(LoadModule .*\/mod_headers\.so\)/\1/' -i /etc/httpd/conf/httpd.conf
-RUN printf 'Include conf/extra/SOGo.conf\n' | tee -a /etc/httpd/conf/httpd.conf
 
+COPY httpd.conf /etc/httpd/conf/httpd.conf
 ADD event_listener.ini /etc/supervisor.d/event_listener.ini
 ADD event_listener.sh /usr/local/bin/event_listener.sh
 RUN chmod +x /usr/local/bin/event_listener.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ ADD sogod.ini /etc/supervisor.d/sogod.ini
 ADD apache.ini /etc/supervisor.d/apache.ini
 ADD cronie.ini /etc/supervisor.d/cronie.ini
 ADD memcached.ini /etc/supervisor.d/memcached.ini
+# clean up
+RUN pacman --noconfirm -Rcns base-devel git && yes | pacman -Sccq
+RUN rm -rf /tmp/* /var/tmp/* /var/cache/pacman/pkg/*
 
 WORKDIR /
 CMD ["/usr/sbin/supervisord", "--nodaemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:latest
 
-RUN pacman --noconfirm --needed -Syu && pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef && yes | pacman -Sccq
+RUN pacman --noconfirm --needed -Syu && pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef cronie && yes | pacman -Sccq
 RUN sed 's/.*MAKEFLAGS=.*/MAKEFLAGS="-j$(nproc)"/' -i /etc/makepkg.conf
 RUN sed 's/^# \(%wheel.*NOPASSWD.*\)/\1/' -i /etc/sudoers
 RUN useradd -r build -G wheel
@@ -42,6 +42,7 @@ RUN mkdir /var/run/sogo && chown sogo:sogo /var/run/sogo
 RUN mkdir /var/spool/sogo && chown sogo:sogo /var/spool/sogo
 ADD sogod.ini /etc/supervisor.d/sogod.ini
 ADD apache.ini /etc/supervisor.d/apache.ini
+ADD cronie.ini /etc/supervisor.d/cronie.ini
 
 WORKDIR /
 CMD ["/usr/sbin/supervisord", "--nodaemon"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # [SOGo](https://sogo.nu/) Docker images based on Arch Linux
+The original author is [Frederick888](https://github.com/Frederick888/docker-archlinux-sogo)
 
 ### Usage
+
+
+the http service is running under the tcp port 20001, apache does a reverse proxy to SOGo tcp 20000, the port 20000 is not needed to be opened.
+
 ```sh
 docker run -d --name sogo --restart always \
     --publish 127.0.0.1:20000:20000 \
     --publish 127.0.0.1:20001:20001 \
-    -v /srv/sogo:/etc/sogo \
-    frederickzh/archlinux-sogo:latest
+    -v ./sogo.conf:/etc/sogo/sogo.conf:Z \
+    -v ./SOGo.conf:/etc/httpd/conf/extra/SOGo.conf:Z \
+    -v ./sogo:/etc/cron.d/sogo:Z \
+    stephdl/sogo:latest
 ```
 
 Alternatively,
@@ -14,10 +21,300 @@ Alternatively,
 ```sh
 docker run -d --name sogo --restart always --network host \
     -v /srv/sogo:/etc/sogo \
-    frederickzh/archlinux-sogo:latest
+    stephdl/sogo:latest
 ```
 ...however it may raise some security concerns.
 
 ### Credits
 https://aur.archlinux.org/packages/sogo/  
 https://aur.archlinux.org/packages/sope/  
+
+
+Example of configuration files
+
+`/etc/sogo/sogo.conf`
+
+```
+{
+  /* *********************  Main SOGo configuration file  **********************
+   *                                                                           *
+   * Since the content of this file is a dictionary in OpenStep plist format,  *
+   * the curly braces enclosing the body of the configuration are mandatory.   *
+   * See the Installation Guide for details on the format.                     *
+   *                                                                           *
+   * C and C++ style comments are supported.                                   *
+   *                                                                           *
+   * This example configuration contains only a subset of all available        *
+   * configuration parameters. Please see the installation guide more details. *
+   *                                                                           *
+   * ~sogo/GNUstep/Defaults/.GNUstepDefaults has precedence over this file,    *
+   * make sure to move it away to avoid unwanted parameter overrides.          *
+   *                                                                           *
+   * **************************************************************************/
+
+  /* Database configuration (mysql://, postgresql:// or oracle://) */
+  //SOGoProfileURL = "postgresql://sogo:sogo@localhost:5432/sogo/sogo_user_profile";
+  //OCSFolderInfoURL = "postgresql://sogo:sogo@localhost:5432/sogo/sogo_folder_info";
+  //OCSSessionsFolderURL = "postgresql://sogo:sogo@localhost:5432/sogo/sogo_sessions_folder";
+
+  /* Mail */
+  //SOGoDraftsFolderName = Drafts;
+  //SOGoSentFolderName = Sent;
+  //SOGoTrashFolderName = Trash;
+  //SOGoJunkFolderName = Junk;
+  //SOGoIMAPServer = "localhost";
+  //SOGoSieveServer = "sieve://127.0.0.1:4190";
+  //SOGoSMTPServer = "smtp://127.0.0.1";
+  //SOGoMailDomain = acme.com;
+  //SOGoMailingMechanism = smtp;
+  //SOGoForceExternalLoginWithEmail = NO;
+  //SOGoMailSpoolPath = /var/spool/sogo;
+  //NGImap4AuthMechanism = "plain";
+  //NGImap4ConnectionStringSeparator = "/";
+
+  /* Notifications */
+  //SOGoAppointmentSendEMailNotifications = NO;
+  //SOGoACLsSendEMailNotifications = NO;
+  //SOGoFoldersSendEMailNotifications = NO;
+
+  /* Authentication */
+  //SOGoPasswordChangeEnabled = YES;
+
+  /* LDAP authentication example */
+  //SOGoUserSources = (
+  //  {
+  //    type = ldap;
+  //    CNFieldName = cn;
+  //    UIDFieldName = uid;
+  //    IDFieldName = uid; // first field of the DN for direct binds
+  //    bindFields = (uid, mail); // array of fields to use for indirect binds
+  //    baseDN = "ou=users,dc=acme,dc=com";
+  //    bindDN = "uid=sogo,ou=users,dc=acme,dc=com";
+  //    bindPassword = qwerty;
+  //    canAuthenticate = YES;
+  //    displayName = "Shared Addresses";
+  //    hostname = "ldap://127.0.0.1:389";
+  //    id = public;
+  //    isAddressBook = YES;
+  //  }
+  //);
+
+  /* LDAP AD/Samba4 example */
+  //SOGoUserSources = (
+  //  {
+  //    type = ldap;
+  //    CNFieldName = cn;
+  //    UIDFieldName = sAMAccountName;
+  //    baseDN = "CN=users,dc=domain,dc=tld";
+  //    bindDN = "CN=sogo,CN=users,DC=domain,DC=tld";
+  //    bindFields = (sAMAccountName, mail);
+  //    bindPassword = password;
+  //    canAuthenticate = YES;
+  //    displayName = "Public";
+  //    hostname = "ldap://127.0.0.1:389";
+  //    filter = "mail = '*'";
+  //    id = directory;
+  //    isAddressBook = YES;
+  //  }
+  //);
+
+
+  /* SQL authentication example */
+  /*  These database columns MUST be present in the view/table:
+   *    c_uid - will be used for authentication -  it's the username or username@domain.tld)
+   *    c_name - which can be identical to c_uid -  will be used to uniquely identify entries
+   *    c_password - password of the user, plain-text, md5 or sha encoded for now
+   *    c_cn - the user's common name - such as "John Doe"
+   *    mail - the user's mail address
+   *  See the installation guide for more details
+   */
+  //SOGoUserSources =
+  //  (
+  //    {
+  //      type = sql;
+  //      id = directory;
+  //      viewURL = "postgresql://sogo:sogo@127.0.0.1:5432/sogo/sogo_view";
+  //      canAuthenticate = YES;
+  //      isAddressBook = YES;
+  //      userPasswordAlgorithm = md5;
+  //    }
+  //  );
+
+  /* Web Interface */
+  //SOGoPageTitle = SOGo;
+  //SOGoVacationEnabled = YES;
+  //SOGoForwardEnabled = YES;
+  //SOGoSieveScriptsEnabled = YES;
+  //SOGoMailAuxiliaryUserAccountsEnabled = YES;
+  //SOGoTrustProxyAuthentication = NO;
+  //SOGoXSRFValidationEnabled = NO;
+
+  /* General - SOGoTimeZone *MUST* be defined */
+  //SOGoLanguage = English;
+  //SOGoTimeZone = America/Montreal;
+  //SOGoCalendarDefaultRoles = (
+  //  PublicDAndTViewer,
+  //  ConfidentialDAndTViewer
+  //);
+  //SOGoSuperUsernames = (sogo1, sogo2); // This is an array - keep the parens!
+  //SxVMemLimit = 384;
+  //WOPidFile = "/var/run/sogo/sogo.pid";
+  //SOGoMemcachedHost = "/var/run/memcached.sock";
+  
+  /* Debug */
+  //SOGoDebugRequests = YES;
+  //SoDebugBaseURL = YES;
+  //ImapDebugEnabled = YES;
+  //LDAPDebugEnabled = YES;
+  //PGDebugEnabled = YES;
+  //MySQL4DebugEnabled = YES;
+  //SOGoUIxDebugEnabled = YES;
+  //WODontZipResponse = YES;
+  //WOLogFile = /var/log/sogo/sogo.log;
+}
+```
+
+
+`/etc/httpd/conf/extra/SOGo.conf`
+
+```Alias /SOGo.woa/WebServerResources/ \
+      /usr/lib/GNUstep/SOGo/WebServerResources/
+Alias /SOGo/WebServerResources/ \
+      /usr/lib/GNUstep/SOGo/WebServerResources/
+
+<Directory /usr/lib/GNUstep/SOGo/>
+    AllowOverride None
+
+    <IfVersion < 2.4>
+        Order deny,allow
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
+
+    # Explicitly allow caching of static content to avoid browser specific behavior.
+    # A resource's URL MUST change in order to have the client load the new version.
+    <IfModule expires_module>
+      ExpiresActive On
+      ExpiresDefault "access plus 1 year"
+    </IfModule>
+</Directory>
+
+# Don't send the Referer header for cross-origin requests
+Header always set Referrer-Policy "same-origin"
+
+<Location /SOGo>
+  # Don't cache dynamic content
+  Header set Cache-Control "max-age=0, no-cache, no-store"
+</Location>
+
+## Uncomment the following to enable proxy-side authentication, you will then
+## need to set the "SOGoTrustProxyAuthentication" SOGo user default to YES and
+## adjust the "x-webobjects-remote-user" proxy header in the "Proxy" section
+## below.
+#
+## For full proxy-side authentication:
+#<Location /SOGo>
+#  AuthType XXX
+#  Require valid-user
+#  SetEnv proxy-nokeepalive 1
+#  Allow from all
+#</Location>
+#
+## For proxy-side authentication only for CardDAV and GroupDAV from external
+## clients:
+#<Location /SOGo/dav>
+#  AuthType XXX
+#  Require valid-user
+#  SetEnv proxy-nokeepalive 1
+#  Allow from all
+#</Location>
+
+ProxyRequests Off
+ProxyPreserveHost On
+SetEnv proxy-nokeepalive 1
+
+# Uncomment the following lines if you experience "Bad gateway" errors with mod_proxy
+#SetEnv proxy-initial-not-pooled 1
+#SetEnv force-proxy-request-1.0 1
+
+# When using CAS, you should uncomment this and install cas-proxy-validate.py
+# in /usr/lib/cgi-bin to reduce server overloading
+#
+# ProxyPass /SOGo/casProxy http://localhost/cgi-bin/cas-proxy-validate.py
+# <Proxy http://localhost/app/cas-proxy-validate.py>
+#   Order deny,allow
+#   Allow from your-cas-host-addr
+# </Proxy>
+
+# Redirect / to /SOGo
+#RedirectMatch ^/$ https://mail.yourdomain.com/SOGo
+
+# Enable to use Microsoft ActiveSync support
+# Note that you MUST have many sogod workers to use ActiveSync.
+# See the SOGo Installation and Configuration guide for more details.
+#
+#ProxyPass /Microsoft-Server-ActiveSync \
+# http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
+# retry=60 connectiontimeout=5 timeout=360
+
+ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0 nocanon
+
+<Proxy http://127.0.0.1:20000/SOGo>
+## Adjust the following to your configuration
+## and make sure to enable the headers module
+  <IfModule headers_module>
+    RequestHeader set "x-webobjects-server-port" "443"
+    SetEnvIf Host (.*) HTTP_HOST=$1
+    RequestHeader set "x-webobjects-server-name" "%{HTTP_HOST}e" env=HTTP_HOST
+    RequestHeader set "x-webobjects-server-url" "https://%{HTTP_HOST}e" env=HTTP_HOST
+
+## When using proxy-side autentication, you need to uncomment and
+## adjust the following line:
+    RequestHeader unset "x-webobjects-remote-user"
+#    RequestHeader set "x-webobjects-remote-user" "%{REMOTE_USER}e" env=REMOTE_USER
+
+    RequestHeader set "x-webobjects-server-protocol" "HTTP/1.0"
+  </IfModule>
+
+  AddDefaultCharset UTF-8
+
+  Order allow,deny
+  Allow from all
+</Proxy>
+
+# For Apple autoconfiguration
+<IfModule rewrite_module>
+  RewriteEngine On
+  RewriteRule ^/.well-known/caldav/?$ /SOGo/dav [R=301]
+  RewriteRule ^/.well-known/carddav/?$ /SOGo/dav [R=301]
+</IfModule>
+```
+
+`/etc/cron.d/sogo`
+
+```
+# Sogod cronjobs
+
+# Vacation messages expiration
+# The credentials file should contain the sieve admin credentials (username:passwd)
+0 0 * * *      sogo	/usr/sbin/sogo-tool update-autoreply -p /etc/sogo/sieve.creds
+
+# Session cleanup - runs every minute
+#   - Ajust the nbMinutes parameter to suit your needs
+# Example: Sessions without activity since 60 minutes will be dropped:
+* * * * *      sogo	/usr/sbin/sogo-tool expire-sessions 60
+
+# Email alarms - runs every minutes
+# If you need to use SMTP AUTH for outgoing mails, specify credentials to use
+# with '-p /path/to/credentialsFile' (same format as the sieve credentials)
+* * * * *      sogo	/usr/sbin/sogo-ealarms-notify > /dev/null 2>&1
+
+# Daily backups
+#   - writes to ~sogo/backups/ by default
+#   - will keep 31 days worth of backups by default
+#   - runs once a day by default, but can run more frequently
+#   - make sure to set the path to sogo-backup.sh correctly
+30 0 * * * sogo /usr/share/doc/sogo-*/sogo-backup.sh
+```

--- a/README.md
+++ b/README.md
@@ -318,3 +318,10 @@ ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0 nocanon
 #   - make sure to set the path to sogo-backup.sh correctly
 30 0 * * * sogo /usr/share/doc/sogo-*/sogo-backup.sh
 ```
+
+
+### Build
+```
+docker build -t  stephdl/sogo:5.9.0 .
+docker push  stephdl/sogo:5.9.0
+```

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Terminate on error
+set -e
+archlinux_version=latest
+# Prepare variables for later use
+images=()
+# The image will be pushed to GitHub container registry
+repobase="${REPOBASE:-ghcr.io/stephdl}"
+
+#Create webtop-webapp container
+reponame="sogo"
+container=$(buildah from docker.io/library/archlinux:${archlinux_version})
+buildah run "${container}" /bin/sh <<'EOF'
+set -e
+pacman --noconfirm --needed -Syu && \
+    pacman --noconfirm --needed -S base-devel git supervisor apache zip inetutils libsodium libzip libytnef cronie && yes | pacman -Sccq && \
+    sed 's/.*MAKEFLAGS=.*/MAKEFLAGS="-j$(nproc)"/' -i /etc/makepkg.conf && \
+    sed 's/^# \(%wheel.*NOPASSWD.*\)/\1/' -i /etc/sudoers &&  \
+    useradd -r build -G wheel && \
+    mkdir /build
+
+(
+    cd /build
+    git clone --depth 1 https://aur.archlinux.org/libwbxml.git && chown -R build ./libwbxml 
+)
+(
+    cd /build/libwbxml
+    sudo -u build makepkg -is --noconfirm && rm -rf /build/libwbxml && yes | pacman -Sccq
+)
+
+(
+    cd /build
+    git clone --depth 1 https://aur.archlinux.org/sope.git &&  chown -R build ./sope
+)
+(
+    cd /build/sope
+    sudo -u build makepkg -is --noconfirm && rm -rf /build/sope && yes | pacman -Sccq
+)
+(
+    cd /build
+    git clone --depth 1 https://aur.archlinux.org/sogo.git &&  chown -R build ./sogo
+)
+(
+    cd /build/sogo
+    sudo -u build makepkg -is --noconfirm && rm -rf /build/sogo && yes | pacman -Sccq
+)
+mkdir /var/run/sogo && chown sogo:sogo /var/run/sogo
+mkdir /var/spool/sogo && chown sogo:sogo /var/spool/sogo
+
+# download backup script
+curl -o /usr/lib/sogo/scripts/sogo-backup.sh https://raw.githubusercontent.com/Alinto/sogo/master/Scripts/sogo-backup.sh
+chmod 755 /usr/lib/sogo/scripts/sogo-backup.sh
+
+# clean up
+pacman --noconfirm -Rcns base-devel git && yes | pacman -Sccq && rm -rf /tmp/* /var/tmp/* /var/cache/pacman/pkg/*
+EOF
+buildah add "${container}" httpd.conf /etc/httpd/conf/httpd.conf
+buildah add "${container}" event_listener.ini /etc/supervisor.d/event_listener.ini
+buildah add "${container}" event_listener.sh /usr/local/bin/event_listener.sh
+buildah add "${container}" sogod.ini /etc/supervisor.d/sogod.ini
+buildah add "${container}" apache.ini /etc/supervisor.d/apache.ini
+buildah add "${container}" cronie.ini /etc/supervisor.d/cronie.ini
+buildah add "${container}" memcached.ini /etc/supervisor.d/memcached.ini
+
+
+buildah config --env LD_PRELOAD=/usr/lib/libytnef.so \
+    --port 20001/tcp \
+    --port 20000/tcp \
+    --workingdir="/" \
+    --cmd='["/usr/sbin/supervisord", "--nodaemon"]' \
+    --label="org.opencontainers.image.source=https://github.com/stephdl/docker-archlinux-sogo" \
+    --label="org.opencontainers.image.authors=Stephane de Labrusse <stephdl@de-labrusse.fr>" \
+    --label="org.opencontainers.image.title=SOGo based on Archlinux" \
+    --label="org.opencontainers.image.description=A sogo container based on Archlinux that provides apache, sogo, memcached and cron" \
+    --label="org.opencontainers.image.licenses=GPL-3.0-or-later" \
+    --label="org.opencontainers.image.url=https://github.com/stephdl/docker-archlinux-sogo" \
+    --label="org.opencontainers.image.documentation=https://github.com/stephdl/docker-archlinux-sogo/blob/master/README.md" \
+    --label="org.opencontainers.image.vendor=NethServer" \
+    "${container}"
+
+# Commit the image
+buildah commit --rm "${container}" "${repobase}/${reponame}"
+
+# Append the image URL to the images array
+images+=("${repobase}/${reponame}")
+
+#
+# Setup CI when pushing to Github. 
+# Warning! docker::// protocol expects lowercase letters (,,)
+if [[ -n "${GITHUB_OUTPUT}" ]]; then
+    # Set output value for Github Actions
+    printf "images=%s\n" "${images[*],,}" >> "${GITHUB_OUTPUT}"
+    printf " - %s:${IMAGETAG:-latest}\n" "${images[@],,}" >> $GITHUB_STEP_SUMMARY
+else
+    # Just print info for manual push
+    printf "Publish the images with:\n\n"
+    for image in "${images[@],,}"; do printf "  buildah push %s docker://%s:%s\n" "${image}" "${image}" "${IMAGETAG:-latest}" ; done
+    printf "\n"
+fi

--- a/cronie.ini
+++ b/cronie.ini
@@ -1,0 +1,12 @@
+[program:cronie]
+command=/usr/sbin/crond -f -m off
+process_name=%(program_name)s
+directory=/tmp
+startsecs=5
+autostart=true
+startretries=3
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,0 +1,543 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot "/etc/httpd"
+
+#
+# Mutex: Allows you to set the mutex mechanism and mutex file directory
+# for individual mutexes, or change the global defaults
+#
+# Uncomment and change the directory if mutexes are file-based and the default
+# mutex file directory is not on a local disk or is not appropriate for some
+# other reason.
+#
+# Mutex default:/run/httpd
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, instead of the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses.
+#
+#Listen 12.34.56.78:80
+Listen 20001
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule mpm_event_module modules/mod_mpm_event.so
+#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+#LoadModule mpm_worker_module modules/mod_mpm_worker.so
+LoadModule authn_file_module modules/mod_authn_file.so
+#LoadModule authn_dbm_module modules/mod_authn_dbm.so
+#LoadModule authn_anon_module modules/mod_authn_anon.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule authn_socache_module modules/mod_authn_socache.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+#LoadModule authz_dbm_module modules/mod_authz_dbm.so
+#LoadModule authz_owner_module modules/mod_authz_owner.so
+#LoadModule authz_dbd_module modules/mod_authz_dbd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+#LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+#LoadModule authnz_fcgi_module modules/mod_authnz_fcgi.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+#LoadModule auth_form_module modules/mod_auth_form.so
+#LoadModule auth_digest_module modules/mod_auth_digest.so
+#LoadModule allowmethods_module modules/mod_allowmethods.so
+#LoadModule file_cache_module modules/mod_file_cache.so
+#LoadModule cache_module modules/mod_cache.so
+#LoadModule cache_disk_module modules/mod_cache_disk.so
+#LoadModule cache_socache_module modules/mod_cache_socache.so
+#LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+#LoadModule socache_dbm_module modules/mod_socache_dbm.so
+#LoadModule socache_memcache_module modules/mod_socache_memcache.so
+#LoadModule socache_redis_module modules/mod_socache_redis.so
+#LoadModule watchdog_module modules/mod_watchdog.so
+#LoadModule macro_module modules/mod_macro.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule echo_module modules/mod_echo.so
+#LoadModule buffer_module modules/mod_buffer.so
+#LoadModule data_module modules/mod_data.so
+#LoadModule ratelimit_module modules/mod_ratelimit.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+#LoadModule ext_filter_module modules/mod_ext_filter.so
+#LoadModule request_module modules/mod_request.so
+LoadModule include_module modules/mod_include.so
+LoadModule filter_module modules/mod_filter.so
+#LoadModule reflector_module modules/mod_reflector.so
+#LoadModule substitute_module modules/mod_substitute.so
+#LoadModule sed_module modules/mod_sed.so
+#LoadModule charset_lite_module modules/mod_charset_lite.so
+#LoadModule deflate_module modules/mod_deflate.so
+#LoadModule xml2enc_module modules/mod_xml2enc.so
+#LoadModule proxy_html_module modules/mod_proxy_html.so
+#LoadModule brotli_module modules/mod_brotli.so
+LoadModule mime_module modules/mod_mime.so
+#LoadModule ldap_module modules/mod_ldap.so
+LoadModule log_config_module modules/mod_log_config.so
+#LoadModule log_debug_module modules/mod_log_debug.so
+#LoadModule log_forensic_module modules/mod_log_forensic.so
+#LoadModule logio_module modules/mod_logio.so
+#LoadModule lua_module modules/mod_lua.so
+LoadModule env_module modules/mod_env.so
+#LoadModule mime_magic_module modules/mod_mime_magic.so
+#LoadModule cern_meta_module modules/mod_cern_meta.so
+#LoadModule expires_module modules/mod_expires.so
+LoadModule headers_module modules/mod_headers.so
+#LoadModule ident_module modules/mod_ident.so
+#LoadModule usertrack_module modules/mod_usertrack.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+#LoadModule remoteip_module modules/mod_remoteip.so
+LoadModule proxy_module modules/mod_proxy.so
+#LoadModule proxy_connect_module modules/mod_proxy_connect.so
+#LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+#LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+#LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
+#LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
+#LoadModule proxy_fdpass_module modules/mod_proxy_fdpass.so
+#LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+#LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+#LoadModule proxy_express_module modules/mod_proxy_express.so
+#LoadModule proxy_hcheck_module modules/mod_proxy_hcheck.so
+#LoadModule session_module modules/mod_session.so
+#LoadModule session_cookie_module modules/mod_session_cookie.so
+#LoadModule session_crypto_module modules/mod_session_crypto.so
+#LoadModule session_dbd_module modules/mod_session_dbd.so
+LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+#LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+#LoadModule ssl_module modules/mod_ssl.so
+#LoadModule dialup_module modules/mod_dialup.so
+#LoadModule http2_module modules/mod_http2.so
+LoadModule proxy_http2_module modules/mod_proxy_http2.so
+#LoadModule md_module modules/mod_md.so
+#LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
+#LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
+#LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
+#LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
+LoadModule unixd_module modules/mod_unixd.so
+#LoadModule systemd_module modules/mod_systemd.so
+#LoadModule heartbeat_module modules/mod_heartbeat.so
+#LoadModule heartmonitor_module modules/mod_heartmonitor.so
+#LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+#LoadModule asis_module modules/mod_asis.so
+#LoadModule info_module modules/mod_info.so
+#LoadModule suexec_module modules/mod_suexec.so
+<IfModule !mpm_prefork_module>
+        #LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+        #LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+#LoadModule dav_fs_module modules/mod_dav_fs.so
+#LoadModule dav_lock_module modules/mod_dav_lock.so
+#LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+#LoadModule imagemap_module modules/mod_imagemap.so
+#LoadModule actions_module modules/mod_actions.so
+#LoadModule speling_module modules/mod_speling.so
+LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+<IfModule unixd_module>
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User http
+Group http
+
+</IfModule>
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin you@example.com
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+#ServerName www.example.com:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/srv/http"
+<Directory "/srv/http">
+    #
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+    #
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
+
+    #
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   AllowOverride FileInfo AuthConfig Limit
+    #
+    AllowOverride None
+
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog /dev/stderr
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    CustomLog "/var/log/httpd/access_log" common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    #CustomLog "/var/log/httpd/access_log" combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/srv/http/cgi-bin/"
+
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+#
+# "/srv/http/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/srv/http/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    #
+    # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
+    # backend servers which have lingering "httpoxy" defects.
+    # 'Proxy' request header is undefined by the IETF, not listed by IANA
+    #
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig conf/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    #AddType text/html .shtml
+    #AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+#MIMEMagicFile conf/magic
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# MaxRanges: Maximum number of Ranges in a request before
+# returning the entire resource, or one of the special
+# values 'default', 'none' or 'unlimited'.
+# Default setting is to accept 200 Ranges.
+#MaxRanges unlimited
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+#EnableSendfile on
+
+# Supplemental configuration
+#
+# The configuration files in the conf/extra/ directory can be 
+# included to add extra features or to modify the default configuration of 
+# the server, or you may simply copy their contents here and change as 
+# necessary.
+
+# Server-pool management (MPM specific)
+Include conf/extra/httpd-mpm.conf
+
+# Multi-language error messages
+Include conf/extra/httpd-multilang-errordoc.conf
+
+# Fancy directory listings
+Include conf/extra/httpd-autoindex.conf
+
+# Language settings
+Include conf/extra/httpd-languages.conf
+
+# User home directories
+Include conf/extra/httpd-userdir.conf
+
+# Real-time info on requests and configuration
+#Include conf/extra/httpd-info.conf
+
+# Virtual hosts
+#Include conf/extra/httpd-vhosts.conf
+
+# Local access to the Apache HTTP Server Manual
+#Include conf/extra/httpd-manual.conf
+
+# Distributed authoring and versioning (WebDAV)
+#Include conf/extra/httpd-dav.conf
+
+# Various default settings
+Include conf/extra/httpd-default.conf
+
+# Configure mod_proxy_html to understand HTML4/XHTML1
+<IfModule proxy_html_module>
+Include conf/extra/proxy-html.conf
+</IfModule>
+
+# Secure (SSL/TLS) connections
+#Include conf/extra/httpd-ssl.conf
+#
+# Note: The following must must be present to support
+#       starting without SSL on platforms with no /dev/random equivalent
+#       but a statically compiled-in mod_ssl.
+#
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>
+
+Include conf/extra/SOGo.conf

--- a/memcached.ini
+++ b/memcached.ini
@@ -1,5 +1,6 @@
 [program:memcached]
-command=/usr/bin/memcached -d -u sogo
+command=/usr/bin/memcached -p 11211 -u sogo -m 256 -c 1024 -t 4
+user=root
 process_name=%(program_name)s
 directory=/tmp
 startsecs=10

--- a/memcached.ini
+++ b/memcached.ini
@@ -1,0 +1,12 @@
+[program:memcached]
+command=/usr/bin/memcached -d -u sogo
+process_name=%(program_name)s
+directory=/tmp
+startsecs=10
+autostart=true
+startretries=3
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/sogod.ini
+++ b/sogod.ini
@@ -1,5 +1,5 @@
 [program:sogod]
-environment=LD_PRELOAD=/usr/lib/libytnef.so
+environment=LD_PRELOAD="/usr/lib/libytnef.so"
 command=/usr/bin/sogod -WOPidFile /var/run/sogo/sogo.pid -WONoDetach YES -WOPort 0.0.0.0:20000 -WOLogFile -
 process_name=%(program_name)s
 directory=/tmp


### PR DESCRIPTION
This pull request adds a new script called build-image.sh that allows for the building of a SOGo container based on Archlinux using buildah. The script includes the necessary dependencies and configurations for the container.